### PR TITLE
CI - Automate Publishing to Sonatype

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,7 +31,7 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     environment: production
-    if: ${{ (github.ref == "main") }}
+    if: ${{ github.ref == 'main' }}
     steps:
     - name: Creating Gradle properties file
       shell: bash

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,7 +31,7 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     environment: production
-    if: ${{ $GITHUB_REF_NAME == "main" }}
+    if: ${{ (github.ref == "main") }}
     steps:
     - name: Creating Gradle properties file
       shell: bash

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,7 +7,7 @@
 
 name: Java Unit Test with Gradle
 
-on: [push, pull_request]
+on: [push]
 
 permissions:
   contents: read

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,6 +31,7 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     environment: production
+    if: ${{ $GITHUB_REF_NAME == "main" }}
     steps:
     - name: Creating Gradle properties file
       shell: bash

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -5,22 +5,16 @@
 # This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
-name: Java CI with Gradle
+name: Java Unit Test with Gradle
 
-on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+on: [push, pull_request]
 
 permissions:
   contents: read
 
 jobs:
-  build:
-
+  test:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK 11
@@ -28,7 +22,36 @@ jobs:
       with:
         java-version: '11'
         distribution: 'temurin'
-    - name: Build with Gradle
+    - name: Test with Gradle
       uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
       with:
         arguments: test
+
+  publish:
+    needs: [test]
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+    - name: Creating Gradle properties file
+      shell: bash
+      env:
+        OSSRHUSERNAME: ${{ secrets.OSSRHUSERNAME }}
+        OSSRHPASSWORD: ${{ secrets.OSSRHPASSWORD }}
+        SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+        SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+        SIGNING_KEY_KEYRING_FILE: ${{ secrets.SIGNING_KEY_KEYRING_FILE }}
+      run: |
+          mkdir -p ~/.gradle/
+          echo $SIGNING_KEY_KEYRING_FILE | base64 --decode > ~/secring.kbx
+          echo "GRADLE_USER_HOME=${HOME}/.gradle" >> $GITHUB_ENV
+          echo "signing.keyId=${SIGNING_KEY_ID}" > ~/.gradle/gradle.properties
+          echo "signing.password=${SIGNING_KEY_PASSWORD}" >> ~/.gradle/gradle.properties
+          echo "signing.secretKeyRingFile=~/secring.kbx" >> ~/.gradle/gradle.properties
+    - name: Publish to Nexus Repository
+      uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+      env:
+        OSSRHUSERNAME: ${{ secrets.OSSRHUSERNAME }}
+        OSSRHPASSWORD: ${{ secrets.OSSRHPASSWORD }}
+      with:
+        gradle-version: 6.0.1
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+    id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
+}
+
+// Metadata
+group 'id.luthfiswees'
+version '0.0.5'
+
+nexusPublishing {
+    repositories {
+        myNexus {
+            nexusUrl = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
+            snapshotRepositoryUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+            username = System.getenv("OSSRHUSERNAME")
+            password = System.getenv("OSSRHPASSWORD")
+        }
+    }
+}

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -13,12 +13,13 @@ plugins {
     // for publishing to artifactory
     id 'maven-publish'
     id 'signing'
+	id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
 }
 
 // Metadata
 group 'id.luthfiswees'
 archivesBaseName = "yaml-manipulator"
-version '0.0.4'
+version '0.0.5'
 
 // source compatibility
 sourceCompatibility = 1.8
@@ -79,8 +80,8 @@ publishing {
 			def snapshotsRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
 			url = project.version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
 			credentials {
-				username = findProperty('ossrhUsername')
-				password = findProperty('ossrhPassword')
+				username = System.getenv("OSSRHUSERNAME")
+				password = System.getenv("OSSRHPASSWORD")
 			}
 		}
 	}
@@ -126,4 +127,15 @@ publishing {
 
 signing {
 	sign publishing.publications.mavenJava
+}
+
+nexusPublishing {
+    repositories {
+        myNexus {
+            nexusUrl = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
+            snapshotRepositoryUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+            username = System.getenv("OSSRHUSERNAME")
+            password = System.getenv("OSSRHPASSWORD")
+        }
+    }
 }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -13,13 +13,10 @@ plugins {
     // for publishing to artifactory
     id 'maven-publish'
     id 'signing'
-	id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
 }
 
 // Metadata
-group 'id.luthfiswees'
 archivesBaseName = "yaml-manipulator"
-version '0.0.5'
 
 // source compatibility
 sourceCompatibility = 1.8
@@ -127,15 +124,4 @@ publishing {
 
 signing {
 	sign publishing.publications.mavenJava
-}
-
-nexusPublishing {
-    repositories {
-        myNexus {
-            nexusUrl = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
-            snapshotRepositoryUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-            username = System.getenv("OSSRHUSERNAME")
-            password = System.getenv("OSSRHPASSWORD")
-        }
-    }
 }


### PR DESCRIPTION
## What

Automate Publishing library to Sonatype's Maven Central

## How
- Add steps for publishing in gradle workflow
- Add nexus publishing plugin
- Integrate `Close` and `Release` process to CI